### PR TITLE
[FIxed] Added checkedState to store and remember Switch component value

### DIFF
--- a/app/src/main/java/com/example/stockexplorer/ui/components/MSwitch.kt
+++ b/app/src/main/java/com/example/stockexplorer/ui/components/MSwitch.kt
@@ -7,6 +7,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -16,12 +18,17 @@ import com.example.stockexplorer.ui.theme.*
 fun MSwitch(
     enabled: Boolean = true,
     checked: Boolean,
-    onCheckedChange: (Boolean) -> Unit,
+    onCheckedChange: ((Boolean) -> Unit)?,
 ) {
+    val checkedState = remember { mutableStateOf(checked) }
+
     Switch(
         enabled = enabled,
-        checked = checked,
-        onCheckedChange = onCheckedChange,
+        checked = checkedState.value,
+        onCheckedChange = {
+            checkedState.value = it
+            onCheckedChange?.invoke(checkedState.value)
+        },
         modifier = Modifier.size(width = 52.dp, height = 32.dp),
         colors = SwitchDefaults.colors(
             checkedThumbColor = Black10,

--- a/app/src/main/java/com/example/stockexplorer/ui/components/MSwitch.kt
+++ b/app/src/main/java/com/example/stockexplorer/ui/components/MSwitch.kt
@@ -17,10 +17,10 @@ import com.example.stockexplorer.ui.theme.*
 @Composable
 fun MSwitch(
     enabled: Boolean = true,
-    checked: Boolean,
+    initialCheckValue: Boolean,
     onCheckedChange: ((Boolean) -> Unit)?,
 ) {
-    val checkedState = remember { mutableStateOf(checked) }
+    val checkedState = remember { mutableStateOf(initialCheckValue) }
 
     Switch(
         enabled = enabled,
@@ -50,24 +50,24 @@ fun MSwitch(
 fun DefaultPreview() {
     Column {
         MSwitch(
-            checked = true,
+            initialCheckValue = true,
             onCheckedChange = {},
         )
         Spacer(modifier = Modifier.height(10.dp))
         MSwitch(
-            checked = false,
-            onCheckedChange = {},
-        )
-        Spacer(modifier = Modifier.height(10.dp))
-        MSwitch(
-            enabled = false,
-            checked = true,
+            initialCheckValue = false,
             onCheckedChange = {},
         )
         Spacer(modifier = Modifier.height(10.dp))
         MSwitch(
             enabled = false,
-            checked = false,
+            initialCheckValue = true,
+            onCheckedChange = {},
+        )
+        Spacer(modifier = Modifier.height(10.dp))
+        MSwitch(
+            enabled = false,
+            initialCheckValue = false,
             onCheckedChange = {},
         )
     }


### PR DESCRIPTION
## Description

- 新增一個參數，來紀錄 component 內部狀態，讓 component 可以切換值 (true/false)，不受外部的影響

### As is 

``` kotlin
Switch(
        enabled = enabled,
        checked = checked, // 外部傳進來的
```

### To be

``` kotlin
// 新增一個參數，來紀錄 component 內部狀態
 val checkedState = remember { mutableStateOf(checked) }

    Switch(
        enabled = enabled,
        checked = checkedState.value,
```