### PR TITLE
[Add] Watchlist clean architecture sample

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,17 +49,37 @@ android {
 }
 
 dependencies {
+    def composeBom = platform('androidx.compose:compose-bom:2023.04.01')
+    implementation composeBom
+    androidTestImplementation composeBom
 
-    implementation 'androidx.core:core-ktx:1.10.0'
+    implementation "org.jetbrains.kotlin:kotlin-reflect:1.8.0"
+    implementation "org.jetbrains.kotlin:kotlin-script-runtime:1.8.10"
+    implementation 'androidx.core:core-ktx:1.10.1'
+    implementation 'androidx.activity:activity-compose:1.7.2'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
-    implementation 'androidx.activity:activity-compose:1.7.1'
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.compose.material3:material3:1.1.0-rc01'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.6.1'
+    implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.6.1"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.1"
+    implementation 'androidx.compose.runtime:runtime-livedata'
+
+    // Compose
+    implementation "androidx.compose.runtime:runtime"
+    implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.compose.material3:material3-window-size-class'
+    implementation 'androidx.compose.ui:ui'
+    implementation 'androidx.compose.foundation:foundation'
+    implementation 'androidx.compose.material:material-icons-extended'
+    implementation 'androidx.compose.ui:ui-tooling-preview'
+    debugImplementation 'androidx.compose.ui:ui-tooling'
+
+    // Compose testing dependencies
+    androidTestImplementation 'androidx.compose.ui:ui-test-junit4'
+    debugImplementation 'androidx.compose.ui:ui-test-manifest'
+
+    // Testing dependencies
+    androidTestImplementation "androidx.arch.core:core-testing:2.2.0"
+    androidTestImplementation "androidx.test.espresso:espresso-contrib:3.5.1"
+    androidTestImplementation "androidx.test.espresso:espresso-core:3.5.1"
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
 }

--- a/app/src/main/java/com/example/stockexplorer/MainActivity.kt
+++ b/app/src/main/java/com/example/stockexplorer/MainActivity.kt
@@ -10,7 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import com.example.stockexplorer.ui.theme.StockExplorerTheme
+import com.example.stockexplorer.core.ui.theme.StockExplorerTheme
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/example/stockexplorer/core/data/model/Symbol.kt
+++ b/app/src/main/java/com/example/stockexplorer/core/data/model/Symbol.kt
@@ -1,0 +1,11 @@
+package com.example.stockexplorer.core.data.model
+
+data class Symbol(
+    val symbolId: String,
+    val name: String,
+    val price: Double,
+    val isTrial: Boolean,
+    val change: Double,
+    val changePercent: Double,
+    val at: String,
+)

--- a/app/src/main/java/com/example/stockexplorer/core/data/model/Watchlist.kt
+++ b/app/src/main/java/com/example/stockexplorer/core/data/model/Watchlist.kt
@@ -1,0 +1,6 @@
+package com.example.stockexplorer.core.data.model
+
+data class Watchlist(
+    val name: String,
+    val symbols: List<Symbol>
+)

--- a/app/src/main/java/com/example/stockexplorer/core/data/repository/watchlist/MockWatchlistRepositoryImpl.kt
+++ b/app/src/main/java/com/example/stockexplorer/core/data/repository/watchlist/MockWatchlistRepositoryImpl.kt
@@ -1,0 +1,9 @@
+package com.example.stockexplorer.core.data.repository.watchlist
+
+import com.example.stockexplorer.core.data.model.Watchlist
+
+class MockWatchlistRepositoryImpl : WatchlistRepository {
+    override suspend fun getWatchlist(): List<Watchlist> {
+        TODO("Not yet implemented") //todo: 假資料
+    }
+}

--- a/app/src/main/java/com/example/stockexplorer/core/data/repository/watchlist/WatchlistRepository.kt
+++ b/app/src/main/java/com/example/stockexplorer/core/data/repository/watchlist/WatchlistRepository.kt
@@ -1,0 +1,8 @@
+package com.example.stockexplorer.core.data.repository.watchlist
+
+import com.example.stockexplorer.core.data.model.Watchlist
+
+interface WatchlistRepository {
+    // todo: 暫時使用 Entity 當作 model，如果有接真實資料，在改為 WatchlistDTO
+    suspend fun getWatchlist(): List<Watchlist>
+}

--- a/app/src/main/java/com/example/stockexplorer/core/domain/GetWatchlistUseCase.kt
+++ b/app/src/main/java/com/example/stockexplorer/core/domain/GetWatchlistUseCase.kt
@@ -1,0 +1,11 @@
+package com.example.stockexplorer.core.domain
+
+import com.example.stockexplorer.core.data.model.Watchlist
+import com.example.stockexplorer.core.data.repository.watchlist.WatchlistRepository
+
+class GetWatchlistUseCase(private val repository: WatchlistRepository) {
+
+    // todo: 可能需要不同來源的資料組合再一起，建立一個 entity 物件，將所有需要的資料放進去
+    // todo: 目前還不確定需要什麼，所以先不建立
+    suspend operator fun invoke(): List<Watchlist> = repository.getWatchlist()
+}

--- a/app/src/main/java/com/example/stockexplorer/core/ui/components/MSwitch.kt
+++ b/app/src/main/java/com/example/stockexplorer/core/ui/components/MSwitch.kt
@@ -1,4 +1,4 @@
-package com.example.stockexplorer.ui.components
+package com.example.stockexplorer.core.ui.components
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -12,6 +12,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.example.stockexplorer.core.ui.theme.Black10
+import com.example.stockexplorer.core.ui.theme.Black15
+import com.example.stockexplorer.core.ui.theme.Black20
+import com.example.stockexplorer.core.ui.theme.Black35
+import com.example.stockexplorer.core.ui.theme.Black50
+import com.example.stockexplorer.core.ui.theme.Black60
+import com.example.stockexplorer.core.ui.theme.Black70
+import com.example.stockexplorer.core.ui.theme.Blue40
+import com.example.stockexplorer.core.ui.theme.Blue70
 import com.example.stockexplorer.ui.theme.*
 
 @Composable

--- a/app/src/main/java/com/example/stockexplorer/core/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/stockexplorer/core/ui/theme/Color.kt
@@ -1,4 +1,4 @@
-package com.example.stockexplorer.ui.theme
+package com.example.stockexplorer.core.ui.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/app/src/main/java/com/example/stockexplorer/core/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/stockexplorer/core/ui/theme/Theme.kt
@@ -1,4 +1,4 @@
-package com.example.stockexplorer.ui.theme
+package com.example.stockexplorer.core.ui.theme
 
 import android.app.Activity
 import androidx.compose.foundation.isSystemInDarkTheme

--- a/app/src/main/java/com/example/stockexplorer/core/ui/theme/Type.kt
+++ b/app/src/main/java/com/example/stockexplorer/core/ui/theme/Type.kt
@@ -1,4 +1,4 @@
-package com.example.stockexplorer.ui.theme
+package com.example.stockexplorer.core.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle

--- a/app/src/main/java/com/example/stockexplorer/feature/watchlist/WatchlistScreen.kt
+++ b/app/src/main/java/com/example/stockexplorer/feature/watchlist/WatchlistScreen.kt
@@ -1,0 +1,37 @@
+package com.example.stockexplorer.feature.watchlist
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.example.stockexplorer.core.data.repository.watchlist.MockWatchlistRepositoryImpl
+import com.example.stockexplorer.core.domain.GetWatchlistUseCase
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WatchlistScreen(
+    viewModel: WatchlistViewModel = WatchlistViewModel(
+        GetWatchlistUseCase(
+            MockWatchlistRepositoryImpl()
+        )
+    )
+) {
+    val screenState by viewModel.watchlist.observeAsState(initial = WatchlistScreenState(emptyList()))
+
+    Scaffold(
+        topBar = {}
+    ) { innerPadding ->
+        Box(modifier = Modifier.padding(innerPadding))
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun WatchlistScreenPreview() {
+
+}

--- a/app/src/main/java/com/example/stockexplorer/feature/watchlist/WatchlistViewModel.kt
+++ b/app/src/main/java/com/example/stockexplorer/feature/watchlist/WatchlistViewModel.kt
@@ -1,0 +1,30 @@
+package com.example.stockexplorer.feature.watchlist
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.stockexplorer.core.data.model.Watchlist
+import com.example.stockexplorer.core.domain.GetWatchlistUseCase
+import kotlinx.coroutines.launch
+
+class WatchlistViewModel(private val getWatchlistUseCase: GetWatchlistUseCase) : ViewModel() {
+
+    init {
+        fetchWatchlist()
+    }
+
+    private val _watchlist = MutableLiveData<WatchlistScreenState>()
+    val watchlist: LiveData<WatchlistScreenState> = _watchlist
+
+    private fun fetchWatchlist() = viewModelScope.launch {
+        val result = getWatchlistUseCase.invoke()
+        _watchlist.value = WatchlistScreenState(watchlistGroup = result)
+    }
+}
+
+@Immutable
+data class WatchlistScreenState( // todo: 所有畫面所需要的資料，都放在這裡
+    val watchlistGroup: List<Watchlist>
+)

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 buildscript {
     ext {
-        compose_version = '1.4.2'
+        compose_version = '1.4.3'
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '7.4.2' apply false
-    id 'com.android.library' version '7.4.2' apply false
+    id 'com.android.application' version '8.0.1' apply false
+    id 'com.android.library' version '8.0.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.buildconfig=true
+android.nonFinalResIds=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Apr 21 23:40:29 CST 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Description

建立基礎的 Watchlist 頁面結構，遵循 Clean architecture

## Architecture

<img src="https://github.com/make-a-good-soup/stock-explorer-android/assets/17996728/2788b4c1-ad31-474e-bbfb-e412988e7b75" width=400 />

### Core

Core 主要包含兩個部分

* data: 用來取得資料，及存放資料的 data model
* domain: 用來依照使用方式，將資料進一步分類跟打包，舉例來說，追蹤模組如果同時需要 `追蹤清單資訊` & `使用者資訊`，就可以建立一個 `追蹤模組 usecase`，將模組所需要的資料，取得並處理後打包成一個 entity 物件，讓外部使用


好處是資料與模組的資料間，不會有強烈的耦合關係，今天再建立一個新的模組，需要使用 `追蹤清單資訊` + `公告資訊`，不會影響 data 層，與已經建立的 `追蹤模組 usecase`

### Feature

Feature 層就比較簡單，依照不同的頁面，建立不同的功能模組，ex: 追蹤清單頁面 WatchlistScreen ，並建立頁面所需要的 ViewModel

<img src="https://github.com/make-a-good-soup/stock-explorer-android/assets/17996728/290a67f9-3c28-4cb3-abb5-fa6fac57b4bd" width=400 />
