### PR TITLE
[Add] Main screen architecture

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,13 +49,14 @@ android {
 }
 
 dependencies {
-
+    def nav_version = "2.6.0"
     implementation 'androidx.core:core-ktx:1.10.0'
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
     implementation 'androidx.activity:activity-compose:1.7.1'
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation 'androidx.compose.material3:material3:1.1.0-rc01'
+    implementation "androidx.navigation:navigation-compose:$nav_version"
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/src/main/java/com/example/stockexplorer/MainActivity.kt
+++ b/app/src/main/java/com/example/stockexplorer/MainActivity.kt
@@ -6,10 +6,8 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import com.example.stockexplorer.presentation.ui.main.MainScreen
 import com.example.stockexplorer.presentation.ui.theme.StockExplorerTheme
 
 class MainActivity : ComponentActivity() {
@@ -18,23 +16,13 @@ class MainActivity : ComponentActivity() {
         setContent {
             StockExplorerTheme {
                 // A surface container using the 'background' color from the theme
-                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-                    Greeting("Android")
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    MainScreen()
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String) {
-    Text(text = "Hello $name!")
-}
-
-@Preview(showBackground = true)
-@Composable
-fun DefaultPreview() {
-    StockExplorerTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/example/stockexplorer/presentation/Screen.kt
+++ b/app/src/main/java/com/example/stockexplorer/presentation/Screen.kt
@@ -1,0 +1,7 @@
+package com.example.stockexplorer.presentation
+
+sealed class Screen(val route: String) {
+    object Watchlist : Screen("watchlist")
+    object News : Screen("news")
+    object Profile : Screen("profile")
+}

--- a/app/src/main/java/com/example/stockexplorer/presentation/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/example/stockexplorer/presentation/ui/main/MainScreen.kt
@@ -1,0 +1,74 @@
+package com.example.stockexplorer.presentation.ui.main
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.stockexplorer.presentation.Screen
+import com.example.stockexplorer.presentation.ui.news.NewsScreen
+import com.example.stockexplorer.presentation.ui.profile.ProfileScreen
+import com.example.stockexplorer.presentation.ui.watchlist.WatchlistScreen
+
+@Composable
+fun MainScreen() {
+    val navController = rememberNavController()
+    val selectedItemIndex = remember { mutableStateOf(0) }
+
+    val items = listOf(
+        Screen.Watchlist,
+        Screen.News,
+        Screen.Profile
+    )
+
+    Scaffold(
+        bottomBar = {
+            NavigationBar {
+                items.forEachIndexed { index, screen ->
+                    NavigationBarItem(
+                        icon = {
+                            Icon(
+                                Icons.Default.Favorite,
+                                contentDescription = null
+                            )
+                        }, // replace with appropriate icon
+                        label = { Text(screen.route) },
+                        selected = index == selectedItemIndex.value,
+                        onClick = {
+                            selectedItemIndex.value = index
+                            navController.navigate(screen.route) {
+                                launchSingleTop = true
+                            }
+                        }
+                    )
+                }
+            }
+        }
+    ) {
+        Box(Modifier.padding(it)) {
+            NavHost(navController, startDestination = Screen.Watchlist.route) {
+                composable(Screen.Watchlist.route) { WatchlistScreen() }
+                composable(Screen.News.route) { NewsScreen() }
+                composable(Screen.Profile.route) { ProfileScreen() }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MainScreenPreview() {
+    MainScreen()
+}

--- a/app/src/main/java/com/example/stockexplorer/presentation/ui/news/NewsScreen.kt
+++ b/app/src/main/java/com/example/stockexplorer/presentation/ui/news/NewsScreen.kt
@@ -1,0 +1,34 @@
+package com.example.stockexplorer.presentation.ui.news
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun NewsScreen() {
+    // TODO: Implement NewsScreen
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("最新消息") }
+            )
+        }
+    ) { innerPadding ->
+        Text(
+            text = "Hello, Jetpack Compose!",
+            modifier = Modifier.padding(innerPadding)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NewsScreenPreview() {
+    NewsScreen()
+}

--- a/app/src/main/java/com/example/stockexplorer/presentation/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/example/stockexplorer/presentation/ui/profile/ProfileScreen.kt
@@ -1,0 +1,34 @@
+package com.example.stockexplorer.presentation.ui.profile
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileScreen() {
+    // TODO: Implement ProfileScreen
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("會員") }
+            )
+        }
+    ) { innerPadding ->
+        Text(
+            text = "Hello, Jetpack Compose!",
+            modifier = Modifier.padding(innerPadding)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ProfileScreenPreview() {
+    ProfileScreen()
+}

--- a/app/src/main/java/com/example/stockexplorer/presentation/ui/watchlist/WatchlistScreen.kt
+++ b/app/src/main/java/com/example/stockexplorer/presentation/ui/watchlist/WatchlistScreen.kt
@@ -1,0 +1,34 @@
+package com.example.stockexplorer.presentation.ui.watchlist
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WatchlistScreen() {
+    // TODO: Implement WatchlistScreen
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("追蹤清單") }
+            )
+        }
+    ) { innerPadding ->
+        Text(
+            text = "Hello, Jetpack Compose!",
+            modifier = Modifier.padding(innerPadding)
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun WatchlistScreenPreview() {
+    WatchlistScreen()
+}


### PR DESCRIPTION
## Description

新增主畫面的架構

## Architecture

主要是使用了 [jetpack-navigation](https://developer.android.com/jetpack/androidx/releases/navigation) library 來完成主頁切換不同 tab 的行為

[main_screen.webm](https://github.com/make-a-good-soup/stock-explorer-android/assets/17996728/982fd2bd-c6e1-43f0-8fed-dfbbfd208fa9)


### 新增追蹤、新聞、個股資料 Tab UI 畫面

* commit: 894e7f2b3bbc33100b0b23797add839195fe2840

先新增三個頁面，後續有需要再調整

### 新增 Navigation library

* commit: 6219c8a7411f535238e446ff46072f88c9d08b3d

### 新增 MainScreen

* commit: aa1e503c5ed427c519548af59c97eff6b6d83323

``` kt
@Composable
fun MainScreen() {
    val navController = rememberNavController()
    val selectedItemIndex = remember { mutableStateOf(0) }

    val items = listOf(
        Screen.Watchlist,
        Screen.News,
        Screen.Profile
    )

    Scaffold(
        bottomBar = {
            NavigationBar {
                items.forEachIndexed { index, screen ->
                    NavigationBarItem(
                        icon = {...},
                        label = {...},
                        selected = index == selectedItemIndex.value,
                        onClick = {
                            selectedItemIndex.value = index
                            navController.navigate(screen.route) { // 3️⃣ 透過 navigation controller 來切換頁面，類似 flutter 的 Navigator.pushName("/watchlist")
                                launchSingleTop = true
                            }
                        }
                    )
                }
            }
        }
    ) {
        Box(Modifier.padding(it)) {
            NavHost(navController, startDestination = Screen.Watchlist.route) {  // 1️⃣  新增 NavHost 類似 Flutter 的 Navigator
                composable(Screen.Watchlist.route) { WatchlistScreen() }  // 2️⃣ 配置 route path 跟 畫面 (Screen.Watchlist.route = "/watchlist")
                composable(Screen.News.route) { NewsScreen() }
                composable(Screen.Profile.route) { ProfileScreen() }
            }
        }
    }
}
```


